### PR TITLE
Add binary datatype support for Postgres BYTEA

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,6 +139,11 @@ utils.prepareValue = function(value) {
     value = JSON.stringify(value);
   }
 
+  // Store Buffers as hex strings (for BYTEA)
+  if (Buffer.isBuffer(value)) {
+    value = '\\x' + value.toString('hex');
+  }
+
   return value;
 };
 
@@ -228,6 +233,10 @@ utils.sqlTypeCast = function(type) {
 
     case 'json':
       return 'JSON';
+
+    case 'binary':
+    case 'bytea':
+      return 'BYTEA';
 
     default:
       console.error("Unregistered type given: " + type);


### PR DESCRIPTION
Waterline supports binary datatypes, so map them to BYTEA column
types in Postgres.  Convert buffers to hex strings (as per the
tradition in node-postgres) starting with \x, which will automatically
be converted back into Buffer objects when read from Postgres by
node-postgres.

See
https://github.com/brianc/node-postgres/issues/184
and
parseByteA of https://github.com/brianc/node-postgres/blob/master/lib/types/textParsers.js
