### PR TITLE
Fix adapter.define callbacks to prevent deadlock.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -188,9 +188,12 @@ module.exports = (function() {
           // Build indexes in series
           async.eachSeries(indexes, buildIndex, function(err) {
             if(err) return cb(err);
-
+            // Must call the callback here to release the pool instance.
+            // If you don't, adapter.describe results in deadlock since
+            // the pool instance owned by adapter.define is not yet released.
+            cb();
             // Describe (sets schema)
-            adapter.describe(table.replace(/["']/g, ""), cb);
+            adapter.describe(table.replace(/["']/g, ""), function() { });
           });
         });
 


### PR DESCRIPTION
adapter.define and adapter.describe both try spawnConnection,
but adapter.define consumes all of the instances in the
pool (10, by default, in node-postgres) and thus the
adapter.describe function called at the end of adapter.define
results in deadlock (with very nasty effects to your database)

This is a MAJOR show stopper bug.

Recommendation for future code refactoring: don't call every callback `cb`, because it makes it very difficult to determine which callback is in scope and which one has been called.
