### PR TITLE
make camelCase columns work for cause sensitive column types

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -302,6 +302,7 @@ Query.prototype.operators = function() {
 
       // Check case sensitivity to decide if LOWER logic is used
       if(!caseSensitivity) key = 'LOWER("' + key + '")';
+      else key = '"' + key + '"'; // for case sensitive camelCase columns
 
       // Build IN query
       self._query += key + ' IN (';

--- a/test/unit/query.where.js
+++ b/test/unit/query.where.js
@@ -129,10 +129,27 @@ describe('query', function() {
         }
       };
 
+      var camelCaseCriteria = {
+        where: {
+          myId: [
+            1,
+            2,
+            3
+          ]
+        }
+      };
+
       it('should build a SELECT statement with an IN array', function() {
         var query = new Query({ name: { type: 'text' }}).find('test', criteria);
 
         query.query.should.eql('SELECT * FROM test WHERE LOWER("name") IN ($1, $2, $3)');
+        query.values.length.should.eql(3);
+      });
+
+      it('should build a SELECT statememnt with an IN array and camel case column', function() {
+        var query = new Query({ myId: { type: 'integer' }}).find('test', camelCaseCriteria);
+
+        query.query.should.eql('SELECT * FROM test WHERE "myId" IN ($1, $2, $3)');
         query.values.length.should.eql(3);
       });
 


### PR DESCRIPTION
I am using camel case for my models attributes and found out that queries using the in operator with camel case columns wouldn't work. So something like:

```
Comment.find().where({"postId": [1,2] }).done(function(err, comments) {});
```

would not work.

This fixes this problem. I also wrote a test to make sure it doesn't brake anything else.
