### PR TITLE
Add the database option to README so you don't have to look in the sourc...

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following config options are available along with their default values:
 
 ```javascript
 config: {
+  database: 'databaseName',
   host: 'localhost',
   user: 'root',
   password: '',


### PR DESCRIPTION
I had to go looking in the source to find how to specify the database I wanted. This option should be documented so it's clear how you specify a database when configuring sails-postgresql.
