### PR TITLE
Nasty fix for OR operator being applied instead of AND

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -197,6 +197,7 @@ Query.prototype.where = function(options) {
 
       case 'or':
 
+        self._query += '(';
         options[key].forEach(function(statement) {
           Object.keys(statement).forEach(function(key) {
 
@@ -227,6 +228,11 @@ Query.prototype.where = function(options) {
 
           });
         });
+        // Remove trailing OR if it exists
+        if(self._query.slice(-3) === 'OR ') {
+          self._query = self._query.slice(0, -4);
+        }
+        self._query += ') AND ';
 
         return;
 


### PR DESCRIPTION
This is a rather nasty fix for `OR` operators being used instead of `(...) AND`. See issue #28.

Ideally, I think `where()` should work recursively and use something along the lines of nested arrays instead of concatenating strings as it goes. Each array would end up as `(...)` in the final query, so that something like the following would work:

``` javascript
{
  or: [
    field1: 'value',
    {like: {field2: '%value%'}},
    and: [
      field3: 'value',
      field4: 'value'
    ]
  ],
  field5: 'value'
}
```

which would give something like:

``` sql
[...] WHERE (field1 = 'value' OR field2 LIKE '%value%' OR (field3 = 'value' AND field4 = 'value')) AND field5 = 'value';
```
