### PR TITLE
fix migrate='safe' branch v0.10

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -38,6 +38,8 @@ module.exports = (function() {
     // Register a new DB Connection
     registerConnection: function(connection, collections, cb) {
 
+      var self = this;
+      
       if(!connection.identity) return cb(Errors.IdentityMissing);
       if(connections[connection.identity]) return cb(Errors.IdentityDuplicate);
 
@@ -47,7 +49,10 @@ module.exports = (function() {
         collections: collections
       };
 
-      return cb();
+      // Always call describe
+      async.map(Object.keys(collections), function(colName, cb){
+        self.describe(connection.identity, colName, cb)
+      }, cb);
     },
 
     // Teardown


### PR DESCRIPTION
I get this error when I use the option `migrate='safe'`

```
[err] Server Error (500)
[err] TypeError: Object.keys called on non-object
    at Function.keys (native)
    at Object.utils.buildSelectStatement (/home/proyectobiota/node_modules/sails-postgresql/lib/utils.js:338:10)
    at Query.find (/home/proyectobiota/node_modules/sails-postgresql/lib/query.js:41:23)
    at __FIND__ (/home/proyectobiota/node_modules/sails-postgresql/lib/adapter.js:397:30)
    at after (/home/proyectobiota/node_modules/sails-postgresql/lib/adapter.js:534:7)
    at /home/proyectobiota/node_modules/sails-postgresql/lib/adapter.js:520:7
    at /home/proyectobiota/node_modules/pg/lib/pool.js:55:9
    at dispense (/home/proyectobiota/node_modules/pg/node_modules/generic-pool/lib/generic-pool.js:247:16)
    at Object.me.acquire (/home/proyectobiota/node_modules/pg/node_modules/generic-pool/lib/generic-pool.js:316:5)
    at Object.pool.connect (/home/proyectobiota/node_modules/pg/lib/pool.js:53:12)
```

I figure out that in master branch, the function `registerCollection` always calls `describe`, so I did that here, then the bug was fixed.
