### PR TITLE
createEach: sequences update

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -372,6 +372,17 @@ module.exports = (function() {
                           : '';
         var tableName = schemaName + utils.escapeName(table);
 
+        var incrementSequences = [];
+
+        // Loop through all the attributes being inserted and check if a sequence was used
+        Object.keys(collection.schema).forEach(function(schemaKey) {
+          if(!utils.object.hasOwnProperty(collection.schema[schemaKey], 'autoIncrement')) return;
+          incrementSequences.push({
+            key: schemaKey,
+            value: 0
+          });
+        });
+
         // Build a Query Object
         var _query = new Query(collection.definition);
 
@@ -398,12 +409,43 @@ module.exports = (function() {
             var values = _query.cast(result.rows[0]);
 
             results.push(values);
-            cb();
+            if(incrementSequences.length === 0) return cb(null, values);
+
+            function checkSequence(item, next) {
+              var currentValue  = item.value;
+              var sequenceValue = values[item.key];
+
+              if(currentValue < sequenceValue) {
+                item.value = sequenceValue;
+              }
+              next();
+            }
+
+            async.each(incrementSequences, checkSequence, function(err) {
+              if(err) return cb(err);
+              cb(null, values);
+            });
           });
 
         }, function(err) {
           if(err) return cb(err);
-          cb(null, results);
+          if(incrementSequences.length === 0) return cb(null, results);
+
+          function setSequence(item, next) {
+            var sequenceName = "'" + table + '_' + item.key + '_seq' + "'";
+            var sequenceValue = item.value;
+            var sequenceQuery = 'SELECT setval(' + sequenceName + ', ' + sequenceValue + ', true)';
+
+            client.query(sequenceQuery, function(err, result) {
+              if(err) return next(err);
+              next();
+            });
+          }
+
+          async.each(incrementSequences, setSequence, function(err) {
+            if(err) return cb(err);
+            cb(null, results);
+          });
         });
 
       }, cb);


### PR DESCRIPTION
When using `migrate: alter` Waterline drops tables and sequences.
So after migrations sequences are uninitialized. It makes impossible to create rows in models with sequences as PK.
