### PR TITLE
Escape values

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -203,7 +203,7 @@ module.exports = (function() {
             var cleanTable = table.replace(/['"]/g, '');
 
             // Build a query to create a namespaced index tableName_key
-            var query = 'CREATE INDEX ' + cleanTable + '_' + name + ' on ' + table + ' (' + name + ');';
+            var query = 'CREATE INDEX ' + utils.escapeName(cleanTable + '_' + name) + ' on ' + table + ' (' + utils.escapeName(name) + ');';
 
             // Run Query
             client.query(query, function(err, result) {


### PR DESCRIPTION
I've added quotes around the values because postgresql otherwise forces them to lower case. This will cause creation of indexes to fail if the column it's being applied on contains SomethingLikeThis.

This has to do [with this issue](https://github.com/balderdashy/waterline/issues/332)
