### PR TITLE
To lower case object fix

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -427,7 +427,7 @@ Query.prototype.operators = function() {
           //if we have an object iterate over the children making them all lowercase
           }else if(typeof value == "object"){
             Object.keys(value).forEach(function(key) {
-              value[key]=value[key].toLowerCase()
+              value[key]=value[key].toLowerCase();
             });
           }
         }


### PR DESCRIPTION
Fixes error calling toLowerCase() on an object resulting in an error:

```
Object has no method 'toLowerCase'
```

This is a fix for the issue I created here: https://github.com/balderdashy/sails-postgresql/issues/80

Please let me know when this is merged to the version on NPM as this is causing an error in an app I plan on deploying to Heroku and I'd like to use the NPM version of the module (and not my fork).
