### PR TITLE
VARCHAR is created when using type 'string'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,9 +80,11 @@ utils.buildSchema = function(obj) {
     // Override Type for autoIncrement
     if(attr.autoIncrement) attr.type = 'serial';
 
+    var maxLength = attr.maxLength || 255;
+
     var str = [
       '"' + key + '"',                        // attribute name
-      utils.sqlTypeCast(attr.type),           // attribute type
+      utils.sqlTypeCast(attr.type, maxLength),           // attribute type
       attr.primaryKey ? 'PRIMARY KEY' : '',   // primary key
       attr.unique ? 'UNIQUE' : '',            // unique constraint
       attr.notNull ? 'NOT NULL': ''           // not null constraint
@@ -224,12 +226,14 @@ utils.toSqlDate = function(date) {
  * Cast waterline types to Postgresql data types
  */
 
-utils.sqlTypeCast = function(type) {
+utils.sqlTypeCast = function(type, maxLength) {
   switch(type.toLowerCase()) {
     case 'serial':
       return 'SERIAL';
 
     case 'string':
+      return 'VARCHAR(' + maxLength + ')';
+
     case 'text':
     case 'mediumtext':
     case 'longtext':

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -28,7 +28,10 @@ describe('adapter', function() {
     },
     email : 'string',
     title : 'string',
-    phone : 'string',
+    phone : {
+      type: 'string',
+      maxLength: 10
+    },
     type  : 'string',
     favoriteFruit : {
       defaultsTo: 'blueberry',
@@ -54,6 +57,8 @@ describe('adapter', function() {
           adapter.describe('test', 'test_define', function(err, result) {
             Object.keys(result).length.should.eql(8);
             done();
+            result.email.type.should.eql('character varying(255)');
+            result.phone.type.should.eql('character varying(10)');
           });
         });
 


### PR DESCRIPTION
This allows the data type of 'string' to create a VARCHAR instead of a TEXT. It also supports maxLength if provided, and defaults to 255 if not.

Fixes [https://github.com/balderdashy/sails-postgresql/issues/83](https://github.com/balderdashy/sails-postgresql/issues/83)
