### PR TITLE
Enabling failOnError flag from waterline-adapter-tests

### DIFF
--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -76,6 +76,7 @@ new TestRunner({
     ssl: false
   },
 
+  failOnError: true,
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
   interfaces: interfaces


### PR DESCRIPTION
Version 0.10.5 of waterline-adapter-tests added a flag that causes the test process to fail with an error if the tests fail. Prior versions of 0.10 always returned 0 (a success). This is problematic because Travis bases success/failure of the tests on this return value; effectively short-circuiting Travis as a test-runner.

That said, this PR WILL cause the Travis tests to start failing. These are not errors introduced with this PR, but an unmasking of existing errors.
