### PR TITLE
Changes to get Travis builds to succeed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
 services: postgresql
+addons:
+  postgresql: "9.3"
 env:
   - DB_USER=postgres DB_PASS=''
 before_script:

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -59,7 +59,7 @@ new TestRunner({
 
   // Mocha opts
   mocha: {
-    bail: true
+    bail: false
   },
 
   // Load the adapter module.


### PR DESCRIPTION
A few changes to improve Travis CI results:
- Removed Node 0.8 due to several dependencies not supporting it anymore.
- Explicitly using Postgresql 9.3 in tests
- Switching tests to not bail on the first error to get a better overall test picture

This will allow the tests to actually run instead of the 0 passing/1 failing failure in the "before all" hook.
