### PR TITLE
Using postgres 'varchar'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -223,6 +223,8 @@ utils.sqlTypeCast = function(type) {
       return 'BIGSERIAL';
 
     case 'string':
+        return 'varchar(255)';
+      
     case 'text':
     case 'mediumtext':
     case 'longtext':


### PR DESCRIPTION
I think it's more convenient to use 'varchar' rather than 'text' if the data type is a string.