### PR TITLE
Force-drop tables

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -266,7 +266,7 @@ module.exports = (function() {
         function dropTable(item, next) {
 
           // Build Query
-          var query = 'DROP TABLE ' + utils.escapeName(item) + ';';
+          var query = 'DROP TABLE ' + utils.escapeName(item) + ' CASCADE;';
 
           // Run Query
           client.query(query, function __DROP__(err, result) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -5,6 +5,8 @@
 
 // Dependencies
 var pg = require('pg');
+pg.defaults.poolSize = 3;
+
 var _ = require('lodash');
 var url = require('url');
 var async = require('async');

--- a/test/unit/adapter.define.js
+++ b/test/unit/adapter.define.js
@@ -81,7 +81,7 @@ describe('adapter', function() {
 
       after(function(done) {
         support.Client(function(err, client, close) {
-          var query = 'DROP TABLE "user";';
+          var query = 'DROP TABLE "user" CASCADE;';
           client.query(query, function(err) {
 
             // close client

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -136,7 +136,7 @@ Support.Seed = function(tableName, cb) {
 function dropTable(table, client, cb) {
   table = '"' + table + '"';
 
-  var query = "DROP TABLE " + table + ';';
+  var query = "DROP TABLE " + table + ' CASCADE;';
   client.query(query, cb);
 }
 


### PR DESCRIPTION
Removes not only the tables, but also dependencies on the tables (i.e. foreign keys or views).

If you define a view on one of your collections/tables, then waterline cannot drop the model anymore.
This results in some really weird errors when you run (for example) tests that drop and recreate tables a few times; the tables aren't dropped because the view-dependency prohibits it, and you are left with random old data.

To avoid the blocking, you can drop tables with the "CASCADE" option. This also removes the dependencies on the tables, so defining a view is no longer blocking the normal routine.

I added it on all occurrences where tables are dropped. I did, however, not do a deep study in the internals of sails-postgresql, so maybe there is a somewhat cleaner way.