### PR TITLE
added postConnectionQuery configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ config: {
   ssl: false
 };
 ```
+Optionally, *postConnectionQuery* can be used to specify any SQL that should be run after opening a connection, prior to running any other query. This is intended for setting [client connection defaults](http://www.postgresql.org/docs/9.4/static/runtime-config-client.html). For example:
+```javascript
+config: {
+  url: 'postgres://username:password@hostname:port/database',
+  postConnectionQuery: 'SET extra_float_digits = 3;'
+};
+```
 
 We are also testing features for future versions of waterline in postgresql. One of these is case sensitive string searching. In order to enable this feature today you can add the following config flag:
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1007,8 +1007,8 @@ module.exports = (function() {
     if(!connectionObject) return cb(Errors.InvalidConnection);
 
     // If the connection details were supplied as a URL use that. Otherwise,
-    // connect using the configuration object as is.
-    var connectionConfig = connectionObject.config;
+    // connect using the configuration object as is (minus 'postConnectionQuery').
+    var connectionConfig = _.omit(connectionObject.config, 'postConnectionQuery');
     if(_.has(connectionConfig, 'url')) {
       var connectionUrl = url.parse(connectionConfig.url);
       connectionUrl.query = _.omit(connectionConfig, 'url');
@@ -1020,7 +1020,9 @@ module.exports = (function() {
       after(err, client, done);
     });
 
-    // Run logic using connection, then release/close it
+    // Run postConnectionQuery if it exists
+    // , then run logic using connection
+    // , then release/close the connection
     function after(err, client, done) {
       if(err) {
         // console.error("Error creating a connection to Postgresql: " + err);
@@ -1123,12 +1125,32 @@ module.exports = (function() {
         return cb(err);
       }
 
-      logic(client, function(err, result) {
+      // If the connectionObject config has a 'postConnectionQuery'
+      // then run it if it hasn't already been run
+      var postConnectionQuery = connectionObject.config.postConnectionQuery;
+      if(postConnectionQuery && !client.connection._sails_hasRunPostConnectionQuery) {
+        client.query(postConnectionQuery, function(err, result) {
+          if(err) {
+            // be sure to release connection
+            done();
+            return cb(err);
+          }
+          client.connection._sails_hasRunPostConnectionQuery = true;
+          // Run logic using connection, then release/close it
+          runLogic();
+        });
+      } else {
+        // Run logic using connection, then release/close it
+        runLogic();
+      }
 
-        // release client connection
-        done();
-        return cb(err, result);
-      });
+      function runLogic() {
+        logic(client, function(err, result) {
+          // release client connection
+          done();
+          return cb(err, result);
+        });
+      }
     }
   }
 


### PR DESCRIPTION
I needed to set [client-connection defaults](http://www.postgresql.org/docs/9.4/static/runtime-config-client.html), specifically 'SET extra_float_digits = 3;' to run before any other SQL query. This fixes an issue with double precision values being truncated (which I reported to node-postgres a while ago but got no response for - [Issue 730](https://github.com/brianc/node-postgres/issues/730)).

As a generic way to set any of these parameters, I figured the ability to specify a SQL query that runs once whenever a new connection is opened would be best. So I added a *postConnectionQuery* configuration option, and modified the *adapter.spawnConnection* function. I toyed with the idea of specifying a JSON object or array of parameters instead, but figured directly specifying a SQL string would be easier and more flexible.

Also I'm not entirely sure how best to unit test this. As I couldn't see any tests on spawnConnection I have not made new ones.