### PR TITLE
Throw error when limit is passed to update

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -883,6 +883,10 @@ module.exports = (function() {
 
     // Update one or more models in the collection
     update: function(connectionName, table, options, data, cb) {
+      //LIMIT in a postgresql UPDATE command is not valid
+      if (hop(options, 'limit')) {
+        return cb(new Error('Your \'LIMIT ' + options.limit + '\' is not allowed in the PostgreSQL UPDATE query.'));
+      }
       spawnConnection(connectionName, function __UPDATE__(client, cb) {
 
         var connectionObject = connections[connectionName];


### PR DESCRIPTION
Discussed the issue with @devinivy and a bit with @dmarcelino.

Before that when you passed `limit` the query just got generated and more or less silently failed.