### PR TITLE
Update waterline-sequel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "~2.4.1",
     "async": "~0.9.0",
     "waterline-errors": "~0.10.0",
-    "waterline-sequel": "~0.1.1",
+    "waterline-sequel": "~0.2.0",
     "waterline-cursor": "~0.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "~2.4.1",
     "async": "~0.9.0",
     "waterline-errors": "~0.10.0",
-    "waterline-sequel": "~0.2.0",
+    "waterline-sequel": "~0.3.0",
     "waterline-cursor": "~0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Given that there has been [32 commits](https://github.com/balderdashy/waterline-sequel/compare/0.1.1...master) in waterline-sequel since `0.1.1` it's probably a good idea to update this dependency to something fresher.

We probably should issue a new waterline-sequel release given that the integration build is kosher: [![Circle CI](https://img.shields.io/circleci/project/balderdashy/waterline-sequel/master.svg?style=shield)](https://circleci.com/gh/balderdashy/waterline-sequel/tree/master)

This depends on balderdashy/waterline-sequel#37.