### PR TITLE
Process results on join

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -595,6 +595,7 @@ module.exports = (function() {
 
             // Build Query
             var _schema = connectionObject.schema;
+            var processor = new Processor(_schema);
 
             // Mixin WL Next connection overrides to sqlOptions
             var overrides = connectionOverrides[connectionName] || {};
@@ -652,7 +653,9 @@ module.exports = (function() {
                   // Pull out any aliased child records that have come from a hasFK association
                   async.eachSeries(parentRecords, splitChildren, function(err) {
                     if(err) return next(err);
-                    buffers.parents = parentRecords;
+                    buffers.parents = parentRecords.map(function(row) {
+                        return processor.cast(table, row);
+                    });
                     next();
                   });
                 });


### PR DESCRIPTION
Currently `find()` uses `processor` to cast result records, and `join()` does not. This PR adds processing to parent records of `join()` results. Child records still need to be processed.