### PR TITLE
Attach the original Postgres error to unique errors

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1232,6 +1232,9 @@ module.exports = (function() {
       if (matches && matches.length) {
         formattedErr = {};
         formattedErr.code = 'E_UNIQUE';
+        // This is the same property that is set on WLError instances.
+        // Accessible as `.originalError` on a WLValidationError instance.
+        formattedErr.originalError = err;
         formattedErr.invalidAttributes = {};
         formattedErr.invalidAttributes[matches[1]] = [{
           value: matches[2],


### PR DESCRIPTION
Currently it gets clobbered, which makes it difficult to determine which
uniqueness constraint failed. This way, you can always check err.originalError
to get the original node-postgres error message, with information about the
constraint, PG error code and table that failed.