### PR TITLE
Remove prepareValue for array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -145,11 +145,6 @@ utils.prepareValue = function(value) {
     value = value.toString();
   }
 
-  // Store Arrays as strings
-  if (Array.isArray(value)) {
-    value = JSON.stringify(value);
-  }
-
   // Store Buffers as hex strings (for BYTEA)
   if (Buffer.isBuffer(value)) {
     value = '\\x' + value.toString('hex');


### PR DESCRIPTION
PostgreSQL already has 'array' type, there is no need to transform 'array' to 'string'.