### PR TITLE
Escape table name in describe function

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -145,6 +145,9 @@ module.exports = (function() {
     describe: function(connectionName, table, cb) {
       spawnConnection(connectionName, function __DESCRIBE__(client, cb) {
 
+        // Escape Table Name
+        table = utils.escapeName(table);
+
         var connectionObject = connections[connectionName];
         var collection = connectionObject.collections[table];
 


### PR DESCRIPTION
It looks like table name is escaped in every other call (either directly in the adapter or in waterline-sequel) with the exception of describe. This simply adds the escape.