### PR TITLE
Annotate initial queries

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -151,7 +151,8 @@ module.exports = (function() {
         // Build query to get a bunch of info from the information_schema
         // It's not super important to understand it only that it returns the following fields:
         // [Table, #, Column, Type, Null, Constraint, C, consrc, F Key, Default]
-        var query = "SELECT x.nspname || '.' || x.relname as \"Table\", x.attnum as \"#\", x.attname as \"Column\", x.\"Type\"," +
+        var query = "-- sails-postgresql.describe table information\n" +
+          "SELECT x.nspname || '.' || x.relname as \"Table\", x.attnum as \"#\", x.attname as \"Column\", x.\"Type\"," +
           " case x.attnotnull when true then 'NOT NULL' else '' end as \"NULL\", r.conname as \"Constraint\", r.contype as \"C\", " +
           "r.consrc, fn.nspname || '.' || f.relname as \"F Key\", d.adsrc as \"Default\" FROM (" +
           "SELECT c.oid, a.attrelid, a.attnum, n.nspname, c.relname, a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod) as \"Type\", " +
@@ -164,13 +165,15 @@ module.exports = (function() {
           "where x.relname = '" + table + "' order by 1,2;";
 
         // Get Sequences to test if column auto-increments
-        var autoIncrementQuery = "SELECT t.relname as related_table, a.attname as related_column, s.relname as sequence_name " +
+        var autoIncrementQuery = "-- sails-postgresql.describe auto increment\n" +
+          "SELECT t.relname as related_table, a.attname as related_column, s.relname as sequence_name " +
           "FROM pg_class s JOIN pg_depend d ON d.objid = s.oid JOIN pg_class t ON d.objid = s.oid AND d.refobjid = t.oid " +
           "JOIN pg_attribute a ON (d.refobjid, d.refobjsubid) = (a.attrelid, a.attnum) JOIN pg_namespace n ON n.oid = s.relnamespace " +
           "WHERE s.relkind = 'S' AND n.nspname = 'public';";
 
         // Get Indexes
-        var indiciesQuery = "SELECT n.nspname as \"Schema\", c.relname as \"Name\", CASE c.relkind WHEN 'r' THEN 'table' " +
+        var indicesQuery = "-- sails-postgresql.describe indices\n" +
+          "SELECT n.nspname as \"Schema\", c.relname as \"Name\", CASE c.relkind WHEN 'r' THEN 'table' " +
           "WHEN 'v' THEN 'view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' WHEN 'f' THEN " +
           "'foreign table' END as \"Type\", pg_catalog.pg_get_userbyid(c.relowner) as \"Owner\", c2.relname as \"Table\" " +
           "FROM pg_catalog.pg_class c LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace " +
@@ -199,10 +202,10 @@ module.exports = (function() {
             });
 
             // Run Query to get Indexed values
-            client.query(indiciesQuery, function(err, iResult) {
+            client.query(indicesQuery, function(err, iResult) {
               if(err) return cb(handleQueryError(err));
 
-              // Loop through indicies and see if any match
+              // Loop through indices and see if any match
               iResult.rows.forEach(function(column) {
                 var key = column.Name.split('_index_')[1];
 


### PR DESCRIPTION
When scanning the database logs, annotations make it easier to determine that
the queries came from the sails-postgresql startup sequence.

Fixes a typo - "indices" had an additional "i".