### PR TITLE
Update README include required configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following config options are available along with their default values:
 
 ```javascript
 config: {
+  module: 'sails-postgresql', // required if using multiple databases
   database: 'databaseName',
   host: 'localhost',
   user: 'root',


### PR DESCRIPTION
If you use `adapter: 'sails-postgresql'` instead of `module: postgresql` it breaks.  Thought it worth mentioning in the README.