### PR TITLE
Add support for column comments

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -251,6 +251,9 @@ module.exports = (function() {
         // Check for any Index attributes
         var indexes = utils.buildIndexes(definition);
 
+        // Check for any Comment attributes
+        var comments = utils.buildComments(definition);
+
         // Build Query
         var query = 'CREATE TABLE ' + table + ' (' + _schema + ')';
 
@@ -275,7 +278,27 @@ module.exports = (function() {
           }
 
           // Build indexes in series
-          async.eachSeries(indexes, buildIndex, cb);
+          async.eachSeries(indexes, buildIndex, function __DEFINE__(err, result) {
+            if(err) return cb(handleQueryError(err));
+
+            // Add Comments
+            function buildComment(comment, cb) {
+
+              // Build a query to create a namespaced index tableName_key
+              var query = 'COMMENT ON COLUMN ' + table + '.' + utils.escapeName(comment.attribute) + ' IS \'' + comment.body + '\';';
+
+              // Run Query
+              client.query(query, function(err, result) {
+                if(err) return cb(handleQueryError(err));
+                cb();
+              });
+            }
+
+            // Build comments in series
+            async.eachSeries(comments, buildComment, cb);
+
+          });
+
         });
 
       }, describe);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -153,9 +153,10 @@ module.exports = (function() {
         // [Table, #, Column, Type, Null, Constraint, C, consrc, F Key, Default]
         var query = "SELECT x.nspname || '.' || x.relname as \"Table\", x.attnum as \"#\", x.attname as \"Column\", x.\"Type\"," +
           " case x.attnotnull when true then 'NOT NULL' else '' end as \"NULL\", r.conname as \"Constraint\", r.contype as \"C\", " +
-          "r.consrc, fn.nspname || '.' || f.relname as \"F Key\", d.adsrc as \"Default\" FROM (" +
+          "r.consrc, fn.nspname || '.' || f.relname as \"F Key\", d.adsrc as \"Default\", x.comment as \"Comment\" FROM (" +
           "SELECT c.oid, a.attrelid, a.attnum, n.nspname, c.relname, a.attname, pg_catalog.format_type(a.atttypid, a.atttypmod) as \"Type\", " +
-          "a.attnotnull FROM pg_catalog.pg_attribute a, pg_namespace n, pg_class c WHERE a.attnum > 0 AND NOT a.attisdropped AND a.attrelid = c.oid " +
+          "a.attnotnull, pg_catalog.col_description(c.oid, a.attnum) AS comment FROM pg_catalog.pg_attribute a, pg_namespace n, pg_class c " +
+          "WHERE a.attnum > 0 AND NOT a.attisdropped AND a.attrelid = c.oid " +
           "and c.relkind not in ('S','v') and c.relnamespace = n.oid and n.nspname not in ('pg_catalog','pg_toast','information_schema')) x " +
           "left join pg_attrdef d on d.adrelid = x.attrelid and d.adnum = x.attnum " +
           "left join pg_constraint r on r.conrelid = x.oid and r.conkey[1] = x.attnum " +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,6 +104,24 @@ utils.buildIndexes = function(obj) {
 
 
 /**
+ * Build a Comment array from any attributes that
+ * have a comment key set.
+ */
+
+utils.buildComments = function(obj) {
+  var comments = [];
+
+  // Iterate through the Object keys and pull out any index attributes
+  Object.keys(obj).forEach(function(key) {
+    if(obj[key].hasOwnProperty('comment')) {
+      comments.push({ attribute: key, body: obj[key].comment });
+    }
+  });
+
+  return comments;
+};
+
+/**
  * Map Attributes
  *
  * Takes a js object and creates arrays used for parameterized

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,6 +211,11 @@ utils.normalizeSchema = function(schema) {
       normalized[column.Column].indexed = column.indexed;
     }
 
+    // Check for comment
+    if(column.Comment) {
+      normalized[column.Column].comment = column.Comment;
+    }
+
   });
 
   return normalized;

--- a/test/unit/support/bootstrap.js
+++ b/test/unit/support/bootstrap.js
@@ -42,7 +42,7 @@ Support.Collection = function(name, def) {
 // Fixture Table Definition
 Support.Definition = {
   field_1: { type: 'string' },
-  field_2: { type: 'string' },
+  field_2: { type: 'string', comment: 'This is field_2.' },
   id: {
     type: 'integer',
     autoIncrement: true,


### PR DESCRIPTION
This is related to #197 and adds support for a ```comment``` attribute. The value is returned when calling ```describe```.