### PR TITLE
Prevent password from being reported to stderr

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1115,7 +1115,7 @@ module.exports = (function() {
 
         // Remove password before reporting error so that it doesn't show up in logs
         var connectionValues = _.clone(connectionConfig);
-        delete connectionValues.password;
+        connectionValues.password = '[redacted]';
 
         console.error('');
         console.error('Error creating a connection to Postgresql using the following settings:\n',connectionValues);

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1114,7 +1114,7 @@ module.exports = (function() {
         // sharpened with a few simple heuristics:
 
         // Remove password before reporting error so that it doesn't show up in logs
-        var connectionValues = _.cloneDeep(connectionConfig);
+        var connectionValues = _.clone(connectionConfig);
         delete connectionValues.password;
 
         console.error('');

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1112,8 +1112,13 @@ module.exports = (function() {
 
         // If connection to posgresql fails starting, provide general troubleshooting information,
         // sharpened with a few simple heuristics:
+
+        // Remove password before reporting error so that it doesn't show up in logs
+        var connectionValues = _.cloneDeep(connectionConfig);
+        delete connectionValues.password;
+
         console.error('');
-        console.error('Error creating a connection to Postgresql using the following settings:\n',connectionConfig);
+        console.error('Error creating a connection to Postgresql using the following settings:\n',connectionValues);
         console.error('');
         console.error('* * *\nComplete error details:\n',err);
         console.error('');


### PR DESCRIPTION
This change prevents the password from being reported to stderr when a connection fails. The main motivation for this is that users who have access to the logs may not have access to the passwords. Full account credentials in the logs can lead to security issues.

A failed connection due to an incorrect password will still provide the user with relevant output:
`[error: password authentication failed for user "user_name_here"]`