### PR TITLE
Fix buffers

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -24,13 +24,12 @@ var Processor = module.exports = function Processor(schema) {
 Processor.prototype.cast = function(table, values) {
 
   var self = this;
-  var _values = _.cloneDeep(values);
 
   Object.keys(values).forEach(function(key) {
-    self.castValue(table, key, _values[key], _values);
+    self.castValue(table, key, values[key], values);
   });
 
-  return _values;
+  return values;
 };
 
 /**


### PR DESCRIPTION
Removes the `cloneDeep` as described in #194.

All test pass but someone who is having this issue should test it to be sure.