### PR TITLE
Prevented duplicated records to improve populating performance.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -693,8 +693,13 @@ module.exports = (function() {
 
                         // If null value for the parentVal, ignore it
                         if(parent[parentVal] === null) return;
-
-                        records.push(cachedChild);
+                        // If the same record is alreay there, ignore it
+                        var index = _.findIndex(records, function(record) {
+                          return record[pk] === cachedChild[pk];
+                        });
+                        if (index === -1) {
+                          records.push(cachedChild);
+                        }
                       });
                     }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -680,6 +680,7 @@ module.exports = (function() {
                     };
 
                     var records = [];
+                    var recordsMap = {};
 
                     // Check for any cached parent records
                     if(hop(cachedChildren, alias)) {
@@ -694,11 +695,9 @@ module.exports = (function() {
                         // If null value for the parentVal, ignore it
                         if(parent[parentVal] === null) return;
                         // If the same record is alreay there, ignore it
-                        var index = _.findIndex(records, function(record) {
-                          return record[pk] === cachedChild[pk];
-                        });
-                        if (index === -1) {
+                        if (!recordsMap[cachedChild[childVal]]) {
                           records.push(cachedChild);
+                          recordsMap[cachedChild[childVal]] = true;
                         }
                       });
                     }


### PR DESCRIPTION
This commit is to fix the slow population (and big memory usage) problem as described in:
https://github.com/balderdashy/sails-mysql/issues/161

Although the issue is for MySQL, it also applies to Postgresql.