### PR TITLE
Parse connection url, don't toss away other connection parameters, fixed poolSize bug

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -265,12 +265,12 @@ module.exports = (function() {
         // If the schema name is "public", just finish creating the table
         if (schemaName == 'public') {return _define();}
 
-        // If not, attempt to create the schema first.  This will succeed if 
+        // If not, attempt to create the schema first.  This will succeed if
         // the schema already exists.
         adapter.createSchema(connectionName, table, schemaName, _define);
 
         function _define(errCreatingSchema) {
-          
+
           if (errCreatingSchema) {
             cb(handleQueryError(errCreatingSchema));
           }
@@ -333,7 +333,7 @@ module.exports = (function() {
         throw new Error("No schemaName specified, and could not determined schemaname for table `" + table + "`");
       }
 
-      // Build Query      
+      // Build Query
       var query = 'CREATE SCHEMA "' + schemaName + '"';
 
       spawnConnection(connectionName, function (client, cb) {
@@ -1172,8 +1172,12 @@ module.exports = (function() {
     var connectionConfig = connectionObject.config;
     if(_.has(connectionConfig, 'url')) {
       var connectionUrl = url.parse(connectionConfig.url);
-      connectionUrl.query = _.omit(connectionConfig, 'url');
-      connectionConfig = url.format(connectionUrl);
+      connectionConfig = _.omit(connectionConfig, 'url');
+      connectionConfig.database = _.trim(connectionUrl.pathname, '/');
+      connectionConfig.host = connectionUrl.hostname;
+      connectionConfig.port = connectionUrl.port;
+      connectionConfig.user = connectionUrl.auth.split(':')[0];
+      connectionConfig.password = connectionUrl.auth.split(':')[1];
     }
 
     // Grab a client instance from the client pool
@@ -1327,15 +1331,15 @@ module.exports = (function() {
           rule: 'unique'
         }];
       }
-    } 
+    }
 
-    else if (err.code === '3F000') {      
+    else if (err.code === '3F000') {
       formattedErr = {};
       formattedErr.message = 'Attempted to create a table `' + err.table + '` in a schema `' + err.schemaName + '` that does not exist.  Either create the schema manually or make sure that the `createSchemas` flag in your connection configuration is not set to `false`.';
       delete err.table;
       delete err.schemaName;
       formattedErr.originalError = err;
-    } 
+    }
 
     else if (err.type == 'CREATING_SCHEMA') {
       formattedErr = {};


### PR DESCRIPTION
If a connection url is provided, all the additional options are added as a query string to the url.  This is not how the pg module works.  It does not look for poolSize, for example, on the connection string query.  It still looks for the poolSize as a key value pair.

So instead, this patch will build out the config object, and still allowing for other parameters to be passed through.
