### PR TITLE
Adapter cache processor for each connection instead recreate

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -127,7 +127,8 @@ module.exports = (function() {
       connections[connection.identity] = {
         config: connection,
         collections: collections,
-        schema: schema
+        schema: schema,
+        processor: new Processor(schema) // Cache processor for each connection to avoid deepClone of schema
       };
 
       // Always call describe
@@ -508,7 +509,7 @@ module.exports = (function() {
 
         // Build up a SQL Query
         var schema = connectionObject.schema;
-        var processor = new Processor(schema);
+        var processor = connectionObject.processor; // use cached processor
 
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};
@@ -600,7 +601,7 @@ module.exports = (function() {
 
         // Build up a SQL Query
         var schema = connectionObject.schema;
-        var processor = new Processor(schema);
+        var processor = connectionObject.processor; // use cached processor
 
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};
@@ -1067,7 +1068,7 @@ module.exports = (function() {
 
         // Build Query
         var _schema = connectionObject.schema;
-        var processor = new Processor(_schema);
+        var processor = connectionObject.processor; // use cached processor
 
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};
@@ -1120,7 +1121,7 @@ module.exports = (function() {
 
         // Build Query
         var _schema = connectionObject.schema;
-        var processor = new Processor(_schema);
+        var processor = connectionObject.processor; // use cached processor
 
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};
@@ -1208,7 +1209,7 @@ module.exports = (function() {
         var tableName = table;
 
         var _schema = connectionObject.schema;
-        var processor = new Processor(_schema);
+        var processor = connectionObject.processor; // use cached processor
 
         // Mixin WL Next connection overrides to sqlOptions
         var overrides = connectionOverrides[connectionName] || {};


### PR DESCRIPTION
For every query processor creates and make deepClone of whole schema. It can take much time (100-300 ms with 300 models). Because of this, we have huge overhead in each query (query takes 1-5ms, deepClone takes 150ms). Very big problem is, that deepClone works synchronously, and whole application can be frozen, when many queries being executed.
In this pull request processor being cached in connection object, and no need to recreate it every query and make resource-expensive deepClone. Schema have no modifications in here, it don't need to be recreated every time.