### PR TITLE
bump pg dependency to work with updated versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "1.5.2",
     "lodash": "3.10.1",
-    "pg": "4.4.4",
+    "pg": "4.5.5",
     "waterline-cursor": "0.0.6",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "0.5.7"


### PR DESCRIPTION
Update the postgresql dependency to bring in fix for newer versions of Node.