### PR TITLE
Update pg to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "1.5.2",
     "lodash": "3.10.1",
-    "pg": "4.4.4",
+    "pg": "^4.5.5",
     "waterline-cursor": "0.0.6",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "0.6.2"


### PR DESCRIPTION
While coming up with https://github.com/BlueHotDog/sails-migrations/pull/76, I somehow missed [sails-migrations's](https://github.com/BlueHotDog/sails-migrations) `optionalDependencies` and ended up updating this project's version of [node-postgres](https://github.com/brianc/node-postgres) to 4.5.5.

This should fix any issues with running this on Node 6, as mentioned on https://github.com/brianc/node-postgres/issues/1000.

Additionally, It appears the tests were failing to begin with. Before the fix, I got:

```
76 passing (3s)
2 pending
7 failing
```

Now I get:

```
80 passing (2s)
2 pending
6 failing
```

As this doesn't seem to add up, I'm wondering if this final part is an actual improvement or not.