### PR TITLE
API Changes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1351,12 +1351,9 @@ module.exports = (function() {
   function _getPK(connectionName, collectionName) {
 
     var collectionDefinition;
-
     try {
-      collectionDefinition = connections[connectionName].collections[collectionName].definition;
-      var pk;
-
-      pk = _.find(Object.keys(collectionDefinition), function _findPK(key) {
+      collectionDefinition = connections[connectionName].schema[collectionName].definition;
+      var pk = _.find(_.keys(collectionDefinition), function _findPK (key) {
         var attrDef = collectionDefinition[key];
         if(attrDef && attrDef.primaryKey) {
           return key;
@@ -1364,12 +1361,7 @@ module.exports = (function() {
         else {
           return false;
         }
-      });
-
-      if(!pk) {
-        pk = 'id';
-      }
-
+      }) || 'id';
       return pk;
     }
     catch (e) {
@@ -1571,12 +1563,8 @@ module.exports = (function() {
     return formattedErr || err;
   }
 
-  function getCollection(connectionName, table) {
-    return connections[connectionName].collections[table];
-  }
-
-  function getSchema(collectionOrConnectionName, table) {
-    var collection = table ? getCollection(collectionOrConnectionName, table) : collectionOrConnectionName;
+  function getSchema(connectionName, collectionName) {
+    var collection = connections[connectionName].schema[collectionName];
     return (collection.meta && collection.meta.schemaName) || 'public';
   }
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -65,6 +65,14 @@ module.exports = (function() {
         return cb(Errors.IdentityDuplicate);
       }
 
+      // Set the version of the API
+      var version;
+      if(connection.version) {
+        version = connection.version;
+      } else {
+        version = 0;
+      }
+
       // Store any connection overrides
       connectionOverrides[connection.identity] = {};
 
@@ -85,15 +93,21 @@ module.exports = (function() {
         // Normalize schema into a sane object and discard all the WL context
         var wlSchema = collection.waterline && collection.waterline.schema && collection.waterline.schema[collection.identity];
         var _schema = {};
-        _schema.attributes = wlSchema.attributes || {};
-        _schema.definition = collection.definition || {};
         _schema.meta = collection.meta || {};
         _schema.tableName = wlSchema.tableName;
         _schema.connection = wlSchema.connection;
 
-        // Set defaults to ensure values are set
-        if(!_schema.attributes) {
-          _schema.attributes = {};
+        // If a newer Adapter API is in use, the definition key is used to build
+        // queries and the attributes property can be ignored.
+        //
+        // In older api versions SELECT statements were not normalized. Because of
+        // this the attributes need to be stored that so SELECTS can be manually
+        // normalized in the adapter before sending to the SQL builder.
+        if(version > 0) {
+          _schema.definition = collection.definition || {};
+        } else {
+          _schema.definition = collection.definition || {};
+          _schema.attributes = wlSchema.attributes || {};
         }
 
         if(!_schema.tableName) {
@@ -126,8 +140,8 @@ module.exports = (function() {
       // Store the connection
       connections[connection.identity] = {
         config: connection,
-        collections: collections,
-        schema: schema
+        schema: schema,
+        version: version
       };
 
       // Always call describe
@@ -777,6 +791,7 @@ module.exports = (function() {
 
             // Build Query
             var _schema = connectionObject.schema;
+            var api_version = connectionObject.version;
 
             // Mixin WL Next connection overrides to sqlOptions
             var overrides = connectionOverrides[connectionName] || {};
@@ -787,6 +802,23 @@ module.exports = (function() {
 
             var sequel = new Sequel(_schema, _options);
             var _query;
+
+            // If this is using an older version of the Waterline API and a select
+            // modifier was used, normalize it to column_name values before trying
+            // to build the query.
+            if(api_version < 1 && instructions.select) {
+              var _select = [];
+              _.each(instructions.select, function(selectKey) {
+                var attrs = connectionObject.schema[table] && connectionObject.schema[table].attributes || {};
+                var def = attrs[selectKey] || {};
+                var colName = _.has(def, 'columnName') ? def.columnName : selectKey;
+                _select.push(colName);
+              });
+
+              // Replace the select criteria with normalized values
+              instructions.select = _select;
+            }
+
             // Build a query for the specific query strategy
             try {
               _query = sequel.find(tableName, instructions);
@@ -1059,6 +1091,7 @@ module.exports = (function() {
         var schema = {};
         var connectionObject = connections[connectionName];
         var collection = connectionObject.collections[table];
+        var api_version = connectionObject.version;
         var tableName = table;
 
         Object.keys(connectionObject.collections).forEach(function(coll) {
@@ -1078,6 +1111,22 @@ module.exports = (function() {
 
         var sequel = new Sequel(_schema, _options);
         var _query;
+
+        // If this is using an older version of the Waterline API and a select
+        // modifier was used, normalize it to column_name values before trying
+        // to build the query.
+        if(api_version < 1 && options.select) {
+          var _select = [];
+          _.each(options.select, function(selectKey) {
+            var attrs = connectionObject.schema[table] && connectionObject.schema[table].attributes || {};
+            var def = attrs[selectKey] || {};
+            var colName = _.has(def, 'columnName') ? def.columnName : selectKey;
+            _select.push(colName);
+          });
+
+          // Replace the select criteria with normalized values
+          options.select = _select;
+        }
 
         // Build a query for the specific query strategy
         try {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1187,12 +1187,45 @@ module.exports = (function() {
       client.connect();
 
       // Build Query
-      var _schema = collection.schema;
-      var queryObj = new Query(_schema, schema);
-      var query =queryObj.find(table, options);
+      var _schema = connectionObject.schema;
+
+      // Mixin WL Next connection overrides to sqlOptions
+      var overrides = connectionOverrides[connectionName] || {};
+      var _options = _.cloneDeep(sqlOptions);
+      if(_.has(overrides, 'wlNext')) {
+        _options.wlNext = overrides.wlNext;
+      }
+
+      var sequel = new Sequel(_schema, _options);
+      var _query;
+
+      // If this is using an older version of the Waterline API and a select
+      // modifier was used, normalize it to column_name values before trying
+      // to build the query.
+      if(api_version < 1 && options.select) {
+        var _select = [];
+        _.each(options.select, function(selectKey) {
+          var attrs = connectionObject.schema[table] && connectionObject.schema[table].attributes || {};
+          var def = attrs[selectKey] || {};
+          var colName = _.has(def, 'columnName') ? def.columnName : selectKey;
+          _select.push(colName);
+        });
+
+        // Replace the select criteria with normalized values
+        options.select = _select;
+      }
+
+      // Build a query for the specific query strategy
+      try {
+        _query = sequel.find(tableName, options);
+      } catch(e) {
+        stream.end(); // End stream
+        client.end(); // Close Connection
+        return;
+      }
 
       // Run Query
-      var dbStream = client.query(query.query, query.values);
+      var dbStream = client.query(_query.query[0], _query.values[0]);
 
       //can stream row results back 1 at a time
       dbStream.on('row', function(row) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -194,7 +194,6 @@ module.exports = (function() {
       spawnConnection(connectionName, function __DESCRIBE__(client, cb) {
 
         var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[table];
         var tableName = table;
         var schemaName = getSchema(connectionName, table);
 
@@ -282,9 +281,6 @@ module.exports = (function() {
 
               // Normalize Schema
               var normalizedSchema = utils.normalizeSchema(result.rows);
-
-              // Set Internal Schema Mapping
-              collection.schema = normalizedSchema;
 
               cb(null, normalizedSchema);
             });
@@ -516,9 +512,8 @@ module.exports = (function() {
       spawnConnection(connectionName, function __CREATE__(client, cb) {
 
         var connectionObject = connections[connectionName];
-        var collection = getCollection(connectionName, table);
         var tableName = table;
-        var schemaName = getSchema(collection);
+        var schemaName = getSchema(connectionName, table);
 
         // Build up a SQL Query
         var schema = connectionObject.schema;
@@ -608,9 +603,8 @@ module.exports = (function() {
       spawnConnection(connectionName, function __CREATE_EACH__(client, cb) {
 
         var connectionObject = connections[connectionName];
-        var collection = getCollection(connectionName, table);
         var tableName = table;
-        var schemaName = getSchema(collection);
+        var schemaName = getSchema(connectionName, table);
 
         // Build up a SQL Query
         var schema = connectionObject.schema;
@@ -776,18 +770,10 @@ module.exports = (function() {
 
             // Grab the collection by looking into the connection
             var connectionObject = connections[connectionName];
-            var collection = connectionObject.collections[table];
             var tableName = table;
 
             var parentRecords = [];
             var cachedChildren = {};
-
-            // Grab Connection Schema
-            var schema = {};
-
-            Object.keys(connectionObject.collections).forEach(function(coll) {
-              schema[coll] = connectionObject.collections[coll].schema;
-            });
 
             // Build Query
             var _schema = connectionObject.schema;
@@ -1088,15 +1074,9 @@ module.exports = (function() {
       spawnConnection(connectionName, function __FIND__(client, cb) {
 
         // Grab Connection Schema
-        var schema = {};
         var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[table];
         var api_version = connectionObject.version;
         var tableName = table;
-
-        Object.keys(connectionObject.collections).forEach(function(coll) {
-          schema[coll] = connectionObject.collections[coll].schema;
-        });
 
         // Build Query
         var _schema = connectionObject.schema;
@@ -1158,14 +1138,8 @@ module.exports = (function() {
       spawnConnection(connectionName, function __COUNT__(client, cb) {
 
         // Grab Connection Schema
-        var schema = {};
         var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[table];
         var tableName = table;
-
-        Object.keys(connectionObject.collections).forEach(function(coll) {
-          schema[coll] = connectionObject.collections[coll].schema;
-        });
 
         // Build Query
         var _schema = connectionObject.schema;
@@ -1208,16 +1182,9 @@ module.exports = (function() {
     stream: function(connectionName, table, options, stream) {
 
       var connectionObject = connections[connectionName];
-      var collection = connectionObject.collections[table];
 
       var client = new pg.Client(connectionObject.config);
       client.connect();
-
-      var schema = {};
-
-      Object.keys(connectionObject.collections).forEach(function(coll) {
-        schema[coll] = connectionObject.collections[coll].schema;
-      });
 
       // Build Query
       var _schema = collection.schema;
@@ -1246,14 +1213,15 @@ module.exports = (function() {
 
     // Update one or more models in the collection
     update: function(connectionName, table, options, data, cb) {
-      //LIMIT in a postgresql UPDATE command is not valid
-      if (_.has(options, 'limit')) {
+
+      // LIMIT in a postgresql UPDATE command is not valid
+      if(_.has(options, 'limit')) {
         return cb(new Error('Your \'LIMIT ' + options.limit + '\' is not allowed in the PostgreSQL UPDATE query.'));
       }
+
       spawnConnection(connectionName, function __UPDATE__(client, cb) {
 
         var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[table];
         var tableName = table;
 
         var _schema = connectionObject.schema;
@@ -1300,7 +1268,6 @@ module.exports = (function() {
       spawnConnection(connectionName, function __DELETE__(client, cb) {
 
         var connectionObject = connections[connectionName];
-        var collection = connectionObject.collections[table];
         var tableName = table;
 
         var _schema = connectionObject.schema;

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -145,7 +145,7 @@ module.exports = (function() {
       };
 
       // Always call describe
-      async.map(Object.keys(collections), function(collName, cb){
+      async.map(_.keys(collections), function(collName, cb){
         self.describe(connection.identity, collName, cb);
       }, cb);
     },
@@ -244,13 +244,13 @@ module.exports = (function() {
               return cb(handleQueryError(err));
             }
 
-            aResult.rows.forEach(function(row) {
+            _.each(aResult.rows, function(row) {
               if(row.related_table !== table) {
                 return;
               }
 
               // Look through query results and see if related_column exists
-              result.rows.forEach(function(column) {
+              _.each(result.rows, function(column) {
                 if(column.Column !== row.related_column) {
                   return;
                 }
@@ -266,11 +266,11 @@ module.exports = (function() {
               }
 
               // Loop through indicies and see if any match
-              iResult.rows.forEach(function(column) {
+              _.each(iResult.rows, function(column) {
                 var key = column.Name.split('_index_')[1];
 
                 // Look through query results and see if key exists
-                result.rows.forEach(function(column) {
+                _.each(result.rows, function(column) {
                   if(column.Column !== key) {
                     return;
                   }
@@ -539,12 +539,12 @@ module.exports = (function() {
         }
 
         // Loop through all the attributes being inserted and check if a sequence was used
-        Object.keys(collection.schema).forEach(function(schemaKey) {
-          if(!_.has(collection.schema[schemaKey], 'autoIncrement')) {
+        _.each(_.keys(schema[table].definition), function(schemaKey) {
+          if(!_.has(schema[table].definition[schemaKey], 'autoIncrement')) {
             return;
           }
 
-          if(Object.keys(data).indexOf(schemaKey) < 0) {
+          if(_.indexOf(_.keys(data), schemaKey) < 0) {
             return;
           }
 
@@ -621,8 +621,8 @@ module.exports = (function() {
         var incrementSequences = [];
 
         // Loop through all the attributes being inserted and check if a sequence was used
-        Object.keys(collection.schema).forEach(function(schemaKey) {
-          if(!_.has(collection.schema[schemaKey], 'autoIncrement')) {
+        _.each(_.keys(schema[table].definition), function(schemaKey) {
+          if(!_.has(schema[table].definition[schemaKey], 'autoIncrement')) {
             return;
           }
 
@@ -826,7 +826,7 @@ module.exports = (function() {
                   var splitChildren = function(parent, next) {
                     var cache = {};
 
-                    _.keys(parent).forEach(function(key) {
+                    _.each(_.keys(parent), function(key) {
 
                       // Check if we can split this on our special alias identifier '___' and if
                       // so put the result in the cache
@@ -845,7 +845,7 @@ module.exports = (function() {
 
                     // Combine the local cache into the cachedChildren
                     if(_.keys(cache).length > 0) {
-                      _.keys(cache).forEach(function(pop) {
+                      _.each(_.keys(cache), function(pop) {
                         if(!_.has(cachedChildren, pop)) {
                           cachedChildren[pop] = [];
                         }
@@ -896,7 +896,7 @@ module.exports = (function() {
 
                     // Check for any cached parent records
                     if(_.has(cachedChildren, alias)) {
-                      cachedChildren[alias].forEach(function(cachedChild) {
+                      _.each(cachedChildren[alias], function(cachedChild) {
                         var childVal = popInstructions[0].childKey;
                         var parentVal = popInstructions[0].parentKey;
 
@@ -938,14 +938,14 @@ module.exports = (function() {
                   var qs = '';
                   var pk;
 
-                  if(!Array.isArray(q.instructions)) {
+                  if(!_.isArray(q.instructions)) {
                     pk = _getPK(connectionName, q.instructions.parent);
                   }
                   else if(q.instructions.length > 1) {
                     pk = _getPK(connectionName, q.instructions[0].parent);
                   }
 
-                  parentRecords.forEach(function(parent) {
+                  _.each(parentRecords, function(parent) {
                     if(_.isNumber(parent[pk])) {
                       qs += q.qs.replace('^?^', parent[pk]) + ' UNION ALL ';
                     } else {
@@ -975,14 +975,14 @@ module.exports = (function() {
                   // Add a final sort to the Union clause for integration
                   if(parentRecords.length > 1) {
 
-                    if(!Array.isArray(q.instructions)) {
-                      _.keys(q.instructions.criteria.sort).forEach(function(sortKey) {
+                    if(!_.isArray(q.instructions)) {
+                      _.each(_.keys(q.instructions.criteria.sort), function(sortKey) {
                         addSort(sortKey, q.instructions.criteria.sort);
                       });
                     }
                     else if(q.instructions.length === 2) {
                       prefix = q.instructions[1].child;
-                      _.keys(q.instructions[1].criteria.sort).forEach(function(sortKey) {
+                      _.each(_.keys(q.instructions[1].criteria.sort), function(sortKey) {
                         addSort(sortKey, q.instructions[1].criteria.sort);
                       });
                     }
@@ -999,9 +999,9 @@ module.exports = (function() {
                     }
 
                     var groupedRecords = {};
-                    result.rows.forEach(function(row) {
+                    _.each(result.rows, function(row) {
 
-                      if(!Array.isArray(q.instructions)) {
+                      if(!_.isArray(q.instructions)) {
 
                         if(!_.has(groupedRecords, row[q.instructions.childKey])) {
                           groupedRecords[row[q.instructions.childKey]] = [];
@@ -1027,7 +1027,7 @@ module.exports = (function() {
                       }
                     });
 
-                    buffers.store.forEach(function(buffer) {
+                    _.each(buffers.store, function(buffer) {
                       if(buffer.attrName !== q.attrName) {
                         return;
                       }
@@ -1123,7 +1123,7 @@ module.exports = (function() {
           // Cast special values
           var values = [];
 
-          result.rows.forEach(function(row) {
+          _.each(result.rows, function(row) {
             values.push(processor.cast(tableName, row));
           });
 
@@ -1253,7 +1253,7 @@ module.exports = (function() {
           // Cast special values
           var values = [];
 
-          result.rows.forEach(function(row) {
+          _.each(result.rows, function(row) {
             values.push(processor.cast(tableName, row));
           });
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -44,39 +44,12 @@ Processor.prototype.cast = function(table, values) {
 
  Processor.prototype.castValue = function(table, key, value, attributes) {
 
-  var self = this;
-  var identity = table;
-  var attr;
-
-  // Check for a columnName, serialize so we can do any casting
-  Object.keys(this.schema[identity].attributes).forEach(function(attribute) {
-    if(self.schema[identity].attributes[attribute].columnName === key) {
-      attr = attribute;
-      return;
-    }
-  });
-
+  var attr = this.schema[table] && this.schema[table].definition && this.schema[table].definition[key];
   if(!attr) {
-    attr = key;
-  }
-
-  // Lookup Schema "Type"
-  if(!this.schema[identity] || !this.schema[identity].attributes[attr]) {
     return;
   }
 
-  var type;
-
-  if(!_.isPlainObject(this.schema[identity].attributes[attr])) {
-    type = this.schema[identity].attributes[attr];
-  } else {
-    type = this.schema[identity].attributes[attr].type;
-  }
-
-
-  if(!type) {
-    return;
-  }
+  var type = attr.type;
 
   // Attempt to parse Array
   if(type === 'array') {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -26,7 +26,7 @@ Processor.prototype.cast = function(table, values) {
   var self = this;
   var _values = _.cloneDeep(values);
 
-  Object.keys(values).forEach(function(key) {
+  _.each(_.keys(values), function(key) {
     self.castValue(table, key, _values[key], _values);
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,7 +78,7 @@ utils.buildIndexes = function(obj) {
   var indexes = [];
 
   // Iterate through the Object keys and pull out any index attributes
-  Object.keys(obj).forEach(function(key) {
+  _.each(_.keys(obj), function(key) {
     if(obj[key].hasOwnProperty('index')) {
       indexes.push(key);
     }
@@ -101,7 +101,7 @@ utils.mapAttributes = function(data) {
       params = [], // Param Index, ex: $1, $2
       i = 1;
 
-  Object.keys(data).forEach(function(key) {
+  _.each(_.keys(data), function(key) {
     keys.push('"' + key + '"');
     values.push(utils.prepareValue(data[key]));
     params.push('$' + i);
@@ -131,7 +131,7 @@ utils.prepareValue = function(value) {
   }
 
   // Store Arrays as strings
-  if (Array.isArray(value)) {
+  if (_.isArray(value)) {
     value = JSON.stringify(value);
   }
 
@@ -151,7 +151,7 @@ utils.normalizeSchema = function(schema) {
   var normalized = {};
   var clone = _.clone(schema);
 
-  clone.forEach(function(column) {
+  _.each(clone, function(column) {
 
     // Set Type
     normalized[column.Column] = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,14 +13,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "pg": {
-      "version": "4.4.4",
-      "from": "pg@4.4.4",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-4.4.4.tgz",
+      "version": "4.5.5",
+      "from": "pg@4.5.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.5.tgz",
       "dependencies": {
         "buffer-writer": {
-          "version": "1.0.0",
-          "from": "buffer-writer@1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+          "version": "1.0.1",
+          "from": "buffer-writer@1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
         },
         "generic-pool": {
           "version": "2.1.1",
@@ -38,9 +38,9 @@
           "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
         },
         "pg-types": {
-          "version": "1.10.0",
+          "version": "1.11.0",
           "from": "pg-types@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
           "dependencies": {
             "ap": {
               "version": "0.2.0",
@@ -58,14 +58,14 @@
               "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
             },
             "postgres-date": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "from": "postgres-date@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.2.tgz"
             },
             "postgres-interval": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "from": "postgres-interval@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
@@ -103,21 +103,9 @@
       }
     },
     "waterline-cursor": {
-      "version": "0.0.6",
-      "from": "waterline-cursor@0.0.6",
-      "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.6.tgz",
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-        }
-      }
+      "version": "0.0.7",
+      "from": "waterline-cursor@0.0.7",
+      "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.7.tgz"
     },
     "waterline-errors": {
       "version": "0.10.1",
@@ -125,16 +113,9 @@
       "resolved": "https://registry.npmjs.org/waterline-errors/-/waterline-errors-0.10.1.tgz"
     },
     "waterline-sequel": {
-      "version": "0.6.2",
-      "from": "waterline-sequel@0.6.2",
-      "resolved": "https://registry.npmjs.org/waterline-sequel/-/waterline-sequel-0.6.2.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.0",
-          "from": "lodash@3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz"
-        }
-      }
+      "version": "0.6.4",
+      "from": "waterline-sequel@0.6.4",
+      "resolved": "https://registry.npmjs.org/waterline-sequel/-/waterline-sequel-0.6.4.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "async": "1.5.2",
     "lodash": "3.10.1",
     "pg": "4.5.5",
-    "waterline-cursor": "0.0.6",
+    "waterline-cursor": "0.0.7",
     "waterline-errors": "0.10.1",
     "waterline-sequel": "0.6.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "waterline-sequel": "0.6.2"
   },
   "devDependencies": {
-    "mocha": "2.4.5",
-    "should": "8.2.1",
-    "waterline-adapter-tests": "0.12.0"
+    "mocha": "2.5.3",
+    "should": "9.0.0",
+    "waterline-adapter-tests": "~0.12.1"
   },
   "scripts": {
     "test": "make test",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "waterline-sequel": "0.6.2"
   },
   "devDependencies": {
-    "captains-log": "0.11.11",
     "mocha": "2.4.5",
     "should": "8.2.1",
     "waterline-adapter-tests": "0.12.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pg": "4.5.5",
     "waterline-cursor": "0.0.7",
     "waterline-errors": "0.10.1",
-    "waterline-sequel": "0.6.2"
+    "waterline-sequel": "0.6.4"
   },
   "devDependencies": {
     "mocha": "2.5.3",

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -15,7 +15,6 @@
 
 var util = require('util');
 var mocha = require('mocha');
-var log = require('captains-log')();
 var TestRunner = require('waterline-adapter-tests');
 var Adapter = require('../../lib/adapter');
 
@@ -40,12 +39,12 @@ try {
 
 
 
-log.info('Testing `' + package.name + '`, a Sails/Waterline adapter.');
-log.info('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
-log.info('( ' + interfaces.join(', ') + ' )');
+console.log('Testing `' + package.name + '`, a Sails/Waterline adapter.');
+console.log('Running `waterline-adapter-tests` against ' + interfaces.length + ' interfaces...');
+console.log('( ' + interfaces.join(', ') + ' )');
 console.log();
-log('Latest draft of Waterline adapter interface spec:');
-log('http://links.sailsjs.org/docs/plugins/adapters/interfaces');
+console.log('Latest draft of Waterline adapter interface spec:');
+console.log('http://links.sailsjs.org/docs/plugins/adapters/interfaces');
 console.log();
 
 


### PR DESCRIPTION
A few changes here. The main issue is to check for the existence of a `version` on the connection that is being registered. This will be empty for Waterline `0.11.x` and contain `1` for Waterline `0.12.x` and higher.

The purpose here is to determine if the adapter should normalize `select` values into `columnNames` as expected by the adapter. Previous version of Waterline didn't officially support the `select` modifier so using the updated adapter with these versions was causing compatibility issues.

The other change is simply removing the `collections` property from the connection object. It wasn't being used and to normalize the use of lodash methods a bit.

This also updates the `stream` method to wl-sql.