### PR TITLE
Wrap sequence schema/table name in double quotes

### DIFF
--- a/helpers/set-sequence.js
+++ b/helpers/set-sequence.js
@@ -96,7 +96,7 @@ module.exports = require('machine').build({
         return exits.badConnection(err);
       }
 
-      var sequenceQuery = 'SELECT setval(' + '\'' + schemaName + '.' + inputs.sequenceName + '\', ' + inputs.sequenceValue + ', true)';
+      var sequenceQuery = 'SELECT setval(' + '\'"' + schemaName + '"."' + inputs.sequenceName + '"\', ' + inputs.sequenceValue + ', true)';
 
       // Run Sequence Query
       Helpers.query.runQuery({


### PR DESCRIPTION
Fixes issue w/ automigrate and sequences like "pet_bookmarkedPets_pet__user_bookmarkedPets_id_seq"