### PR TITLE
Fix timestamp column returning Date object

### DIFF
--- a/helpers/private/query/process-each-record.js
+++ b/helpers/private/query/process-each-record.js
@@ -64,6 +64,14 @@ module.exports = function processEachRecord(options) {
           record[columnName] = Number(record[columnName]);
         }
       }
+
+      // Check if the attribute is a string and the value contains a Date object,
+      // then convert the Date object into an ISO 8601 string to pass validations
+      if (attrVal.type === 'string') {
+        if (_.has(record, columnName) && _.isDate(record[columnName])) {
+          record[columnName] = record[columnName].toISOString();
+        }
+      }
     });
   }, true, options.identity, options.orm);
 };


### PR DESCRIPTION
When using a "timestamp" column in PostgreSQL and mapping it to a "string" model attribute in Sails v1, the validation check fails when fetching data because the [postgres-date](https://github.com/bendrucker/postgres-date/blob/master/index.js) module parse date columns and converts them to a javascript Date object which is not a string :

```
Warning: After transforming columnNames back to attribute names, a record
in the result has a value with an unexpected data type for property `expires_at`.
The corresponding attribute declares `type: 'string'` but instead
of that, the actual value is:
2017-07-18T09:38:56.000Z
```

This commit check if the attribute is a string and the value contains a Date object, then convert the Date object into an ISO 8601 string to pass validations.