### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,7 +51,7 @@ utils.buildSchema = function(obj) {
       attribute.type = val;
     }
 
-    var type = utils.sqlTypeCast(attribute.autoIncrement ? 'SERIAL' : attribute.type);
+    var type = utils.sqlTypeCast(attribute.autoIncrement ? 'SERIAL' : attribute.type, attribute.size ? attribute.size : null);
     var nullable = attribute.notNull && 'NOT NULL';
     var unique = attribute.unique && 'UNIQUE';
 
@@ -198,7 +198,7 @@ utils.toSqlDate = function(date) {
  * Cast waterline types to Postgresql data types
  */
 
-utils.sqlTypeCast = function(type) {
+utils.sqlTypeCast = function(type, size) {
   switch (type.toLowerCase()) {
     case 'serial':
       return 'SERIAL';
@@ -208,6 +208,7 @@ utils.sqlTypeCast = function(type) {
       return 'BIGSERIAL';
 
     case 'string':
+      return 'character varying(' + (size ? size : 255) + ')'; // sets the character-varying limit
     case 'text':
     case 'mediumtext':
     case 'longtext':


### PR DESCRIPTION
When I was trying to use the **ORM** to create tables in **postgreSQL** with some column as '_**varying character**_' **datatype**, I found that all string data types are converted into _TEXT_, even if I have given the size as specified in the documentation, the schema was not creating properly. So I made some changes in the case handling portion in **utils.js** file and it started working. If the size handling changes got added, it will be a great help for everyone. I even checked with the **mysql** library , there this particular issue is not present. Thanks.