### PR TITLE
correctly raises error when you have bad model attributes

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -62,12 +62,7 @@ module.exports = (function sailsPostgresql() {
         }).execSync();
       } catch (e) {
         setImmediate(function done() {
-          switch (e.code) {
-            case 'badConfiguration':
-              return cb(e.output);
-            default:
-              return cb(e);
-          }
+          return cb(e);
         });
         return;
       }

--- a/test/adapter/unit/registerdatastore.js
+++ b/test/adapter/unit/registerdatastore.js
@@ -1,0 +1,74 @@
+var assert = require('assert');
+var _ = require('@sailshq/lodash');
+var Adapter = require('../../../lib/adapter');
+var Support = require('../../support/bootstrap');
+
+describe('Unit Tests ::', function() {
+  describe('Register', function() {
+    after(function(done) {
+      Support.Teardown('test', done);
+    });
+
+    it('should throw badConfiguration error', function(done) {
+      var connection = _.cloneDeep(Support.Config);
+      connection.identity = 'test';
+
+      var badDefinition = {
+        id: {
+          columnType: 'serial',
+          required: true,
+          autoIncrement: true
+        },
+        bad: {
+          type: 'number',
+          autoMigrations: {
+            columnType: 'bigint'
+          }
+        }
+      };
+      var collections = {};
+      var collection = Support.Model('test', badDefinition);
+      collections.test = collection;
+
+      Adapter.registerDatastore(connection, collections, function(err) {
+        if (!err) {
+          return done(new Error('Should have thrown badConfiguration'));
+        }
+
+        assert.equal(err.code, 'badConfiguration');
+        return done();
+      });
+    });
+
+    it('should registerDatastore', function(done) {
+      var connection = _.cloneDeep(Support.Config);
+      connection.identity = 'test';
+
+      var goodDefinition = {
+        id: {
+          columnType: 'serial',
+          required: true,
+          autoIncrement: true
+        },
+        good: {
+          type: 'ref',
+          autoMigrations: {
+            columnType: 'bigint'
+          }
+        }
+      };
+      var collections = {};
+      var collection = Support.Model('test', goodDefinition);
+      collections.test = collection;
+
+      Adapter.registerDatastore(connection, collections, function(err) {
+        if (err) {
+          console.log('why?', err);
+          return done(err);
+        }
+
+        return done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Currently in sails 1.0 if you have bad model attributes, sails will fail saying for instance:

```
{ AdapterError: Unexpected error from database adapter: Could not run select() because of 2 problems:
------------------------------------------------------
• "datastore" is required, but it was not defined.
• "models" is required, but it was not defined.
------------------------------------------------------
```

Which is totally not helpful.  With this change, it will actually throw an error telling you there was a badConfiguration error with the description of what is wrong with your attributes.

I'm not sure what the intent was with doing the switch on the e.code, but I noticed sails-mysql doesn't do that, see: https://github.com/balderdashy/sails-mysql/blob/master/lib/adapter.js#L63 so I changed it to work like that and all was well.

I ran into this when I had a model set to type: number and columnType: bigint.  Once I tracked this down I found that I had to change it to type: ref.  Now it will instead say this which is more helpful:

```
Exception: `registerDataStore` failed ("badConfiguration").  The configuration was invalid.
Additional data:

In attribute `bad` of model `test_create`:
The `bigint` column type cannot be used with the `number` attribute type.
Since `bigint` values may be larger than the maximum JavaScript integer size, PostgreSQL will return them as strings.
Therefore, attributes using this column type must be declared as type `string`, `ref` or `json`.
```
