### PR TITLE
Fix registerDatastore Property Checks

### DIFF
--- a/helpers/register-data-store.js
+++ b/helpers/register-data-store.js
@@ -116,7 +116,7 @@ module.exports = require('machine').build({
 
         _.each(modelDef.definition, function checkAttributes(attribute, attributeName) {
 
-          if (attribute.type === 'number' && attribute.autoMigrations.columnType === 'bigint' && !attribute.autoCreatedAt && !attribute.autoUpdatedAt) {
+          if (attribute.type === 'number' && attribute.autoMigrations && attribute.autoMigrations.columnType === 'bigint' && !attribute.autoCreatedAt && !attribute.autoUpdatedAt) {
             throw flaverr('E_BIGINT_TYPE_MISMATCH', new Error('\nIn attribute `' + attributeName + '` of model `' + modelIdentity + '`:\nThe `bigint` column type cannot be used with the `number` attribute type.\nSince `bigint` values may be larger than the maximum JavaScript integer size, PostgreSQL will return them as strings.\nTherefore, attributes using this column type must be declared as type `string`, `ref` or `json`.\n'));
           }
 

--- a/test/adapter/unit/registerdatastore.js
+++ b/test/adapter/unit/registerdatastore.js
@@ -55,6 +55,9 @@ describe('Unit Tests ::', function() {
           autoMigrations: {
             columnType: 'bigint'
           }
+        },
+        anotherGood: {
+          type: 'number'
         }
       };
       var collections = {};


### PR DESCRIPTION
## Description
Check to make sure `autoMigrations` exists before checking its child property `columnType`.

## Issues
This PR should address this issue: https://github.com/balderdashy/sails/issues/4397