### PR TITLE
Test connectivity while registering data store

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -53,23 +53,22 @@ module.exports = (function sailsPostgresql() {
         return cb(new Error('Invalid datastore config. A datastore should contain a unique identity property.'));
       }
 
-      try {
-        Helpers.registerDataStore({
-          identity: identity,
-          config: datastoreConfig,
-          models: models,
-          datastores: datastores,
-          modelDefinitions: modelDefinitions
-        }).execSync();
-      } catch (e) {
-        setImmediate(function done() {
-          return cb(redactPasswords(e));
-        });
-        return;
-      }
-
-      setImmediate(function done() {
-        return cb();
+      Helpers.registerDataStore({
+        identity: identity,
+        config: datastoreConfig,
+        models: models,
+        datastores: datastores,
+        modelDefinitions: modelDefinitions
+      }).switch({
+        badConfiguration: function (err) {
+          return cb(redactPasswords(err));
+        },
+        error: function (err) {
+          return cb(redactPasswords(err));
+        },
+        success: function () {
+          return cb();
+        }
       });
     },
 


### PR DESCRIPTION
Changes in this PR attempt to resolve https://github.com/balderdashy/sails/issues/7095 by trying to acquire and release a connection to the database before it gets registered a datastore. Since acquiring and releasing connections is  async, `register-data-store` was made async as well.

If either of (a) acquiring a connection or (b) subsequent release of connection fails, `register-data-store` returns an error which fails the app from booting.