### PR TITLE
Adding support for case insensitive `like` constraint

### DIFF
--- a/helpers/avg.js
+++ b/helpers/avg.js
@@ -123,7 +123,7 @@ module.exports = require('machine').build({
     // Compile the original Waterline Query
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/helpers/count.js
+++ b/helpers/count.js
@@ -122,7 +122,7 @@ module.exports = require('machine').build({
     // Compile the original Waterline Query
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/helpers/destroy.js
+++ b/helpers/destroy.js
@@ -142,7 +142,7 @@ module.exports = require('machine').build({
     // Compile the original Waterline Query
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/helpers/private/query/compile-statement.js
+++ b/helpers/private/query/compile-statement.js
@@ -15,8 +15,13 @@
 // Transform a Waterline Query Statement into a SQL query.
 
 var PG = require('machinepack-postgresql');
+var modifyWhereClause = require('./modify-where-clause');
 
-module.exports = function compileStatement(statement) {
+module.exports = function compileStatement(statement, meta) {
+  if (statement.where) {
+    statement.where = modifyWhereClause(statement.where, meta);
+  }
+
   var report = PG.compileStatement({
     statement: statement
   }).execSync();

--- a/helpers/private/query/modify-where-clause.js
+++ b/helpers/private/query/modify-where-clause.js
@@ -17,12 +17,12 @@
 var _ = require("@sailshq/lodash");
 
 module.exports = function modifyWhereClause(whereClause, meta) {
-  // Handle empty `where` clause.
-  if (_.keys(whereClause).length === 0) {
+  // Handle empty `where` clause and missing meta.
+  if (_.keys(whereClause).length === 0 || !meta) {
     return whereClause;
   }
 
-  var makeLikeModifierCaseInsensitive = meta && meta.makeLikeModifierCaseInsensitive;
+  var makeLikeModifierCaseInsensitive = meta.makeLikeModifierCaseInsensitive;
 
   // Recursively modify the `where` clause.
   var queryFilter = (function recurse(branch) {

--- a/helpers/private/query/modify-where-clause.js
+++ b/helpers/private/query/modify-where-clause.js
@@ -56,6 +56,6 @@ module.exports = function modifyWhereClause(whereClause, meta) {
     return branch;
   })(whereClause);
 
-  // Return the modified Postgres query filter.
+  // Return the modified query filter.
   return queryFilter;
 };

--- a/helpers/private/query/modify-where-clause.js
+++ b/helpers/private/query/modify-where-clause.js
@@ -1,0 +1,61 @@
+// ███╗   ███╗ ██████╗ ██████╗ ██╗███████╗██╗   ██╗    ██╗    ██╗██╗  ██╗███████╗██████╗ ███████╗
+// ████╗ ████║██╔═══██╗██╔══██╗██║██╔════╝╚██╗ ██╔╝    ██║    ██║██║  ██║██╔════╝██╔══██╗██╔════╝
+// ██╔████╔██║██║   ██║██║  ██║██║█████╗   ╚████╔╝     ██║ █╗ ██║███████║█████╗  ██████╔╝█████╗
+// ██║╚██╔╝██║██║   ██║██║  ██║██║██╔══╝    ╚██╔╝      ██║███╗██║██╔══██║██╔══╝  ██╔══██╗██╔══╝
+// ██║ ╚═╝ ██║╚██████╔╝██████╔╝██║██║        ██║       ╚███╔███╔╝██║  ██║███████╗██║  ██║███████╗
+// ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚═╝╚═╝        ╚═╝        ╚══╝╚══╝ ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚══════╝
+
+//  ██████╗██╗      █████╗ ██╗   ██╗███████╗███████╗
+// ██╔════╝██║     ██╔══██╗██║   ██║██╔════╝██╔════╝
+// ██║     ██║     ███████║██║   ██║███████╗█████╗
+// ██║     ██║     ██╔══██║██║   ██║╚════██║██╔══╝
+// ╚██████╗███████╗██║  ██║╚██████╔╝███████║███████╗
+//  ╚═════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚══════╝
+
+// Modify the where clause of a query object
+
+var _ = require("@sailshq/lodash");
+
+module.exports = function modifyWhereClause(whereClause, meta) {
+  // Handle empty `where` clause.
+  if (_.keys(whereClause).length === 0) {
+    return whereClause;
+  }
+
+  var makeLikeModifierCaseInsensitive = meta && meta.makeLikeModifierCaseInsensitive;
+
+  // Recursively modify the `where` clause.
+  var queryFilter = (function recurse(branch) {
+    var loneKey = _.first(_.keys(branch));
+
+    // Handle AND/OR conditions
+    if (loneKey === "and" || loneKey === "or") {
+      var conjunctsOrDisjuncts = branch[loneKey];
+      branch[loneKey] = _.map(conjunctsOrDisjuncts, function (conjunctOrDisjunct) {
+        return recurse(conjunctOrDisjunct);
+      });
+
+      return branch;
+    }
+
+    // We're dealing with a constraint of some kind.
+    var constraintColumnName = loneKey;
+    var constraint = branch[constraintColumnName];
+
+    // If it's a primitive, return as is.
+    if (_.isString(constraint) || _.isNumber(constraint) || _.isBoolean(constraint) || _.isNull(constraint)) {
+      return branch;
+    }
+
+    // Modify `LIKE` to `ILIKE` if case insensitivity is enabled.
+    if (constraint.like && makeLikeModifierCaseInsensitive) {
+      constraint.ilike = constraint.like;
+      delete constraint.like;
+    }
+
+    return branch;
+  })(whereClause);
+
+  // Return the modified Postgres query filter.
+  return queryFilter;
+};

--- a/helpers/select.js
+++ b/helpers/select.js
@@ -124,7 +124,7 @@ module.exports = require('machine').build({
     // Compile the original Waterline Query
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/helpers/sum.js
+++ b/helpers/sum.js
@@ -123,7 +123,7 @@ module.exports = require('machine').build({
     // Compile the original Waterline Query
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/helpers/update.js
+++ b/helpers/update.js
@@ -171,7 +171,7 @@ module.exports = require('machine').build({
     // Compile statement into a native query.
     var compiledQuery;
     try {
-      compiledQuery = Helpers.query.compileStatement(statement);
+      compiledQuery = Helpers.query.compileStatement(statement, query.meta);
     } catch (e) {
       return exits.error(e);
     }

--- a/lib/private/redact-passwords.js
+++ b/lib/private/redact-passwords.js
@@ -28,4 +28,4 @@ module.exports = function redactPasswords(err) {
     }
   }
   return err;
-}
+};

--- a/test/adapter/unit/destroy.js
+++ b/test/adapter/unit/destroy.js
@@ -47,6 +47,38 @@ describe('Unit Tests ::', function() {
       });
     });
 
+    it('should ensure the record is deleted with case insensitive like', function(done) {
+      var query = {
+        using: 'test_destroy',
+        criteria: {
+          where: {
+            fieldB: {
+              like: 'BAR'
+            }
+          }
+        },
+        meta: {
+          makeLikeModifierCaseInsensitive: true
+        }
+      };
+
+      Adapter.destroy('test', query, function(err) {
+        if (err) {
+          return done(err);
+        }
+
+        Adapter.find('test', query, function(err, results) {
+          if (err) {
+            return done(err);
+          }
+
+          assert.equal(results.length, 0);
+
+          return done();
+        });
+      });
+    });
+
     // Look into the bowels of the PG Driver and ensure the Create function handles
     // it's connections properly.
     it('should release its connection when completed', function(done) {

--- a/test/adapter/unit/find.js
+++ b/test/adapter/unit/find.js
@@ -88,6 +88,34 @@ describe('Unit Tests ::', function() {
       });
     });
 
+    it('should be case insensitive when `meta.makeLikeModifierCaseInsensitive` is true', function(done) {
+      var query = {
+        using: 'test_find',
+        criteria: {
+          where: {
+            fieldB: {
+              like: 'bar_2'
+            }
+          }
+        },
+        meta: {
+          makeLikeModifierCaseInsensitive: true
+        }
+      };
+
+      Adapter.find('test', query, function(err, results) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(_.isArray(results));
+        assert.equal(results.length, 1);
+        assert.equal(_.first(results).fieldB, 'bAr_2');
+
+        return done();
+      });
+    });
+
     it('should return `ref` type attributes unchanged', function(done) {
       var query = {
         using: 'test_find',

--- a/test/adapter/unit/update.js
+++ b/test/adapter/unit/update.js
@@ -81,6 +81,39 @@ describe('Unit Tests ::', function() {
       });
     });
 
+    it('should be case insensitive when `meta.makeLikeModifierCaseInsensitive` is true', function(done) {
+      var query = {
+        using: 'test_update',
+        criteria: {
+          where: {
+            fieldB: {
+              like: 'bar_2'
+            }
+          }
+        },
+        valuesToSet: {
+          fieldA: 'FooBar2'
+        },
+        meta: {
+          fetch: true,
+          makeLikeModifierCaseInsensitive: true
+        }
+      };
+
+      Adapter.update('test', query, function(err, results) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(_.isArray(results));
+        assert.equal(results.length, 1);
+        assert.equal(_.first(results).fieldA, 'FooBar2');
+        assert.equal(_.first(results).fieldB, 'bAr_2');
+
+        return done();
+      });
+    });
+
     // Look into the bowels of the PG Driver and ensure the Create function handles
     // it's connections properly.
     it('should release its connection when completed', function(done) {


### PR DESCRIPTION
Issue - https://github.com/balderdashy/sails/issues/4628

**Change log**
- Passing `meta` from `query` to `compileStatement` from following methods
	- `avg`
	- `count`
	-  `destroy`
	-  `select`
	-  `sum`
	-  `update`
- Adding `meta` as parameter to `compileStatement`
- Adding `modify-where-clause` which checks for `makeLikeModifierCaseInsensitive` in `meta` and replaces `LIKE` with `ILIKE` if present
- Adding test cases for insensitive queries
- Minor eslint fix in `lib/private/redact-passwords.js` (Missing semicolon)

<img width="1054" alt="Screenshot 2024-09-08 at 1 06 47 AM" src="https://github.com/user-attachments/assets/7eda5116-8466-444f-9677-8c8f32ddfe71">
